### PR TITLE
Fix links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ The CWL specifications are divided up into several documents.
 The [User Guide](http://www.commonwl.org/user_guide/) provides a gentle
 introduction to writing CWL command line tools and workflows.
 
-The [Command Line Tool Description Specification](CommandLineTool.html)
+The [Command Line Tool Description Specification](https://www.commonwl.org/v1.1.0-dev1/CommandLineTool.html)
 specifies the document schema and execution semantics for wrapping and
 executing command line tools.
 
-The [Workflow Description Specification](Workflow.html) specifies the document
+The [Workflow Description Specification](https://www.commonwl.org/v1.1.0-dev1/Workflow.html) specifies the document
 schema and execution semantics for composing workflows from components such as
 command line tools and other workflows.
 
 The
-[Semantic Annotations for Linked Avro Data (SALAD) Specification](SchemaSalad.html)
+[Semantic Annotations for Linked Avro Data (SALAD) Specification](https://www.commonwl.org/v1.1.0-dev1/SchemaSalad.html)
 specifies the preprocessing steps that must be applied when loading CWL
 documents and the schema language used to write the above specifications.


### PR DESCRIPTION
@mr-c  I guess we changed where we put the docs - they are now out of the specs repo. I changed the links to point to the main webpage. Thanks!